### PR TITLE
style: streamline trailer section styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,9 +19,10 @@ nav a:hover::after,nav a.active::after{width:100%}
 .hero-img img:hover{transform:scale(1.05)}
 
 /* Trailer section styling */
-.trailer{padding:60px 6%;text-align:center;background:linear-gradient(135deg,var(--pink-light),var(--pink-mid));}
-.trailer-text h2{font-family:'Playfair Display',serif;color:var(--primary);margin:0 0 12px;}
-.trailer-text p{color:var(--pink-strong);max-width:700px;margin:0 auto 30px;}
+.trailer{padding:60px 6%;text-align:center;background:#fff;}
+.trailer-text{max-width:700px;margin:0 auto 40px;}
+.trailer-text h2{font-family:'Playfair Display',serif;color:var(--primary);margin-bottom:16px;font-size:2rem;}
+.trailer-text p{color:var(--pink-strong);margin:0;font-size:1.1rem;line-height:1.6;}
 .trailer-video{max-width:800px;margin:0 auto;aspect-ratio:16/9;border-radius:20px;overflow:hidden;box-shadow:0 16px 40px rgba(0,0,0,0.1);transition:transform .5s;}
 .trailer-video:hover{transform:scale(1.03);}
 .trailer-video iframe{width:100%;height:100%;border:0;}


### PR DESCRIPTION
## Summary
- use white background for trailer section
- refine trailer text layout with centered spacing and larger heading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabcb0bf1883329e1d181c276a13ac